### PR TITLE
Fix consumer.intaddressline SAML Attributes

### DIFF
--- a/library/SamlAttribute.php
+++ b/library/SamlAttribute.php
@@ -129,8 +129,27 @@ class SamlAttribute {
 
     /** Consumer's Int Address Line
      * @var string
+     * @deprecated
+     * @see $ConsumerIntAddressLine1
+     * @see $ConsumerIntAddressLine2
+     * @see $ConsumerIntAddressLine3
      */
     public static $ConsumerIntAddressLine = "urn:nl:bvn:bankid:1.0:consumer.intaddressline1/2/3";
+
+    /** Consumer's Int Address Line 1
+     * @var string
+     */
+    public static $ConsumerIntAddressLine1 = "urn:nl:bvn:bankid:1.0:consumer.intaddressline1";
+
+    /** Consumer's Int Address Line 2
+     * @var string
+     */
+    public static $ConsumerIntAddressLine2 = "urn:nl:bvn:bankid:1.0:consumer.intaddressline2";
+
+    /** Consumer's Int Address Line 3
+     * @var string
+     */
+    public static $ConsumerIntAddressLine3 = "urn:nl:bvn:bankid:1.0:consumer.intaddressline3";
 
     /** Specify the document to be signed
      * @var string

--- a/library/validation/Validator.php
+++ b/library/validation/Validator.php
@@ -186,7 +186,9 @@ class Validator {
                 case SamlAttribute::$ConsumerPartnerLastNamePrefix:
                     self::checkByValue($attrValue, '[[:print:]]{1,10}');
                     break;
-                case SamlAttribute::$ConsumerIntAddressLine:
+                case SamlAttribute::$ConsumerIntAddressLine1:
+                case SamlAttribute::$ConsumerIntAddressLine2:
+                case SamlAttribute::$ConsumerIntAddressLine3:
                     self::checkByValue($attrValue, '[[:print:]]{1,70}');
                     break;
                 case SamlAttribute::$ConsumerTelephone:


### PR DESCRIPTION
The `consumer.intaddressline1/2/3` SAML attribute should be separate attributes. I deprecated the invalid one for backwards compatibility.