### PR TITLE
Fix inconsistent composer package license

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "currence/idin",
   "description": "A PHP library for working with the iDIN protocol",
-  "license": "proprietary",
+  "license": "MIT",
   "autoload": {
     "psr-4": {
       "BankId\\Merchant\\Library\\": ["library"]


### PR DESCRIPTION
The LICENSE file indicates the project is licensed under the MIT license:
https://github.com/Currence-Online/iDIN-libraries-php/blob/be62c3b702c9af21be69816774dc764324813c1c/LICENSE#L1

However, the `package.json` file incorrectly states `proprietary`.
